### PR TITLE
Small additions for clarity in chapters 1-5

### DIFF
--- a/firstoutput.tex
+++ b/firstoutput.tex
@@ -24,6 +24,7 @@ If there aren't enough arguments, or the argument is the wrong type, unexpected 
 To print an integer instead of a string, use the \%d placeholder.
 For example: \lstinline!printf("%d + %d = %d\n", 5, 7, 12);!
 You can use any mixture of placeholders and normal characters in the \emph{format string} that you like.
+To print a \% symbol, use \%\%.
 
 
 Compile the following:
@@ -103,6 +104,8 @@ do {
     Update
 } while(Test);
 \end{lstlisting}
+
+The \emph{do-while} loop differs from the \emph{while} loop by always running the Body and Update once before the Test is performed and the loop loops.
 
 So we could do this:
 \begin{lstlisting}

--- a/linuxenv.tex
+++ b/linuxenv.tex
@@ -82,7 +82,7 @@ gcc -c file1.c
 gcc -c file2.c
 gcc -c file3.c
 \end{verbatim}
-Would compile each of the files (and check them for correctness).
+Would compile each of the files (and check them for correctness) to a corresponding \texttt{.o} file.
 Following that:
 \begin{verbatim}
 gcc file1.o file2.o file3.o 
@@ -94,6 +94,7 @@ Adding \texttt{-Wall} and/or \texttt{-pedantic} will cause \texttt{gcc} to repor
 
 \section{Other notes}
 It may seem obvious, but do not ignore error or warning messages.
+While warnings for other languages often mean ``your code could be written more nicely'', warnings in C often mean ``your code will not do what you think it will''.
 
 You can save error messages by adding \verb|2>errfilename| to the end of a command.
 For example:

--- a/operators.tex
+++ b/operators.tex
@@ -16,7 +16,7 @@ In fact, literal values are also expressions (they evaluate to the value as writ
 The operators $+$ and $-$ work as you would expect.
 Division is written with $/$ and multiplication as $*$.
 
-The \% operator returns the remainder of its arguments.
+The \% operator (known as ``modulo'') returns the remainder of its arguments;
 \texttt{a\%b} returns the remainder when \texttt{a} is divided by \texttt{b}.
 For example: $7\%3$ is $1$   and $23\%5$ is $3$.
 
@@ -48,13 +48,13 @@ int main(int argc, char** argv) {
 
 \noindent Exercise: Modify the program above to test relative precedence of \texttt{+} and \texttt{\%}.
 
-\subsection{Types}
+\subsection{Simple Types}
 All of C's simple types are numeric in some way.
 This includes types which have other purposes (\texttt{char} and \texttt{bool}).
 
 Numeric types can be classified in a number of ways:
 \begin{itemize}
- \item Integer vs Floating point --- \texttt{bool, char, int} are integer types while \texttt{float} and \texttt{double} are floating point types.
+ \item Integer vs Floating point --- \texttt{bool\footnote{\texttt{stdbool.h} must be included to use \texttt{bool} (and \texttt{true} and \texttt{false}).}, char, int} are integer types while \texttt{float} and \texttt{double} are floating point types.
 Arithmetic operators which act on integers \emph{will evaluate to an integer result} so for example, \texttt{5/2} is \texttt{2}, not \texttt{2.5}.
 Do not make this mistake:
 \texttt{float f=2/3;}
@@ -74,7 +74,7 @@ You could also achieve this with a \emph{cast}: \texttt{2/(float)3} or multiplic
  For example:  \texttt{short int}, \texttt{long int} are smaller and larger than normal \texttt{int}s respectively.
  These can be combined with \texttt{signed} and \texttt{unsigned}.
 \end{itemize}
-There are other type modifiers but we'll keep this simple and standard\footnote{For example: \texttt{long long int}  and \texttt{quad double}}.
+There are other type modifiers but we'll keep this simple and standard\footnote{For example: \texttt{long long int}  and \texttt{quad double} are non-standard types.}.
 
 
 To output other types, with \texttt{printf}, different placeholders are required:
@@ -94,6 +94,7 @@ These operators act on the individual bits in the value.
 \begin{itemize}
  \item \lstinline|a&b| --- bitwise \emph{and} of the two values.
  \item \lstinline:a|b: --- bitwise \emph{or} of the two values.
+ \item \lstinline|a^b| --- bitwise \emph{exclusive or} of the two values.
  \item \lstinline|a<<b| --- left shift \texttt{a} by \texttt{b} bits.
  \item \lstinline|a>>b| --- right shift \texttt{a} by \texttt{b} bits.
  \item \lstinline|~a| --- one's complement of \texttt{a}.
@@ -103,6 +104,7 @@ These operators act on the individual bits in the value.
 
 These return a boolean value \texttt{true} or \texttt{false}.
 Remember that in C, \texttt{bool}s are also integer values.
+A 0 indicates false, and any non-zero value represents true.
 
 \lstinline|a < b, a <= b, a > b, a >= b, a != b, a == b|.
 Be careful comparing floating point values, since numerical errors can 
@@ -117,6 +119,7 @@ These look like their bitwise counterparts so it is important not to mix them up
  \item \lstinline|!a|   --- logical \emph{not}. eg: \lstinline@!(a || b) == (!a && !b)@  (deMorgan's law)
 \end{itemize}
 
+\lstinline!&&! and \lstinline!||! are ``short-circuiting'' operators: the second argument will not be evaluated unless required (ie: in \lstinline!false && EXP! and \lstinline!true || EXP!, \texttt{EXP} will not be evaluated).
 
 \section{Other operators}
 


### PR DESCRIPTION
Made some small additions in chapters 1-5 to remove potential confusion,
or added good-to-know information.

Topics clarified:
- how to print a % with printf
- made the difference between while and do-while explicit
- -c compiles to a .o file
- these warnings are not your Java's warnings
- % = modulo
- changed the "Types" subsection to "Simple Types" since no complex
  types are covered
- stdbool.h is required for bool/true/false
- false = 0, true != 0
- ^ = bitwise xor (some students might assume it is pow)
- short-circuiting logical operators
